### PR TITLE
[PROG] 150365 미로 탈출 명령어 (cpp)

### DIFF
--- a/week05/150365_wonseok.cpp
+++ b/week05/150365_wonseok.cpp
@@ -1,0 +1,123 @@
+#include <string>
+#include <vector>
+#include <iostream>
+
+using namespace std;
+
+enum Dir {
+    UP, DOWN, LEFT, RIGHT
+};
+
+struct Direction {
+    Dir dir;
+    char letter;
+};
+
+class Point {
+public:
+    Point(int r, int c): row(r), col(c) {};
+
+    Point get(Dir dir) { 
+        switch (dir) {
+            case DOWN:
+                return down();
+            case LEFT:
+                return left();
+            case RIGHT:
+                return right();
+            case UP:
+                return up();
+        };
+
+        return Point(row, col);
+    }
+
+    Point left() { return Point(row, col-1); }
+    Point right() { return Point(row, col+1); }
+    Point up() { return Point(row-1, col); }
+    Point down() { return Point(row+1, col); }
+
+    int row, col;
+};
+
+class Maze {
+public:
+    Maze(int rows, int cols): rows(rows), cols(cols) {
+        maze = vector<vector<char>>(
+            rows+1, 
+            vector<char>(cols+1, '.')
+        );
+    }
+
+    void setEnd(int row, int col) {
+        maze[row][col] = 'E';
+        end = Point(row, col);
+    }
+
+    string search(int row, int col, int length) {
+        string answer = "";
+        bool found = _search(Point(row, col), answer, 0, length);
+        return (found) ? answer : "impossible";
+    }
+    
+private:
+    bool _search(Point p, string& answer, int depth, int maxDepth) {
+        // 탈출조건: 목표 길이 도달
+        if (depth == maxDepth) {
+            if (maze[p.row][p.col] == 'E') {
+                this->answer = answer;
+                return true;
+            }
+            else return false;
+        }
+        
+        int remainingMoves = maxDepth - depth;
+        int distance = getDistance(p, this->end);
+        // 탈출조건: 최단 경로 도달 불가
+        if (distance > remainingMoves)
+            return false;
+        // 탈출조건: 짝수, 홀수 불일치
+        if (distance % 2 != remainingMoves % 2)
+            return false;
+        
+        for (Direction& dir : dirs) {
+            Point next = p.get(dir.dir);
+            if (isOutofBound(next)) continue;
+
+            answer += dir.letter;
+            bool found = _search(next, answer, depth+1, maxDepth);
+            if (found) return true;
+
+            answer.pop_back();
+        }
+
+        return false;
+    }
+
+    bool isOutofBound(const Point& p) {
+        return (p.row > rows || p.col > cols) ||
+            (p.row <= 0 || p.col <= 0);
+    }
+
+    int getDistance(const Point& p1, const Point& p2) {
+        return abs(p1.row-p2.row) + abs(p1.col-p2.col);
+    }
+
+    vector<vector<char>> maze;
+    vector<Direction> dirs = {
+        Direction{DOWN, 'd'},
+        Direction{LEFT, 'l'},
+        Direction{RIGHT, 'r'},
+        Direction{UP, 'u'}
+    };
+    Point end = Point(0, 0);
+
+    int rows, cols;
+    string answer;
+};
+
+string solution(int n, int m, int x, int y, int r, int c, int k) {
+    Maze maze(n, m);
+    maze.setEnd(r, c);
+    return maze.search(x, y, k);
+}


### PR DESCRIPTION
# 주제

- BFS
- Optimization

# 요약

1. 시작지점으로부터 BFS로 완전탐색을 시도한다.
    - 아래 > 왼쪽 > 오른쪽 > 위쪽 순으로 탐색한다.
2. 한 칸을 탐색할 때마다 경로 문자열을 업데이트한다.
3. 다음과 같은 조건에서 탐색을 종료한다.
    - 답을 찾은 경우
    - 최단 거리보다 남은 횟수가 적은 경우
    - 최단 거리의 홀짝 여부와 남은 횟수의 홀짝 여부가 다른 경우

# 접근과정

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/c256e108-fd9a-4c15-9548-7caa838d19b2/0ffb227e-c06a-4ac4-aef1-54403aa0b425/Untitled.png)

 이 문제는 그래프에서 고정 길이의 경로를 찾는 문제이며, 그 경로에 순서가 주어진 문제이다.

1. 경로를 찾는 데에는 BFS를 이용할 수 있다.
2. BFS 탐색 시 아래 → 왼쪽 → 오른쪽 → 위 순서대로 탐색한다.
3. 가장 처음 목적지에 도달하는 것이 정답이다.

 이때, 최악의 경우 그래프를 완전탐색하고 종료하며 이때 총 $4^k$만큼 탐색하게 된다. 그런데 `k` 의 최대값이 2500이므로 완전탐색 이전에 종료할 방법이 필요하다. 

![< 일단은 메모 없이 최적화부터… >](https://prod-files-secure.s3.us-west-2.amazonaws.com/c256e108-fd9a-4c15-9548-7caa838d19b2/5e0a5023-53bf-48ef-8c12-3bf586f7e1b3/Untitled.png)

< 일단은 메모 없이 최적화부터… >

<aside>
💡 목표지점까지 도달이 불가능하면 더이상 탐색을 하지 않아도 된다.

</aside>

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/c256e108-fd9a-4c15-9548-7caa838d19b2/bfb2cd90-9762-4d2e-966a-e37395891355/Untitled.png)

```cpp
// 탈출조건: 최단 경로 도달 불가
if (distance > remainingMoves)
    return false;
```

 이 하나만 최적화해주어도 하나만 빼고 다 통과한다. 더 최적화할 방법을 찾아야 하는데 메모(Memoization)을 이용할 수 있지 않을까…? 최단 경로가 아니어도 도달이 불가능한 시점을 찾았다면, 이를 메모해서 쓸 수 있을 것 같다.

![< 메모 없이도 되겠네…? >](https://prod-files-secure.s3.us-west-2.amazonaws.com/c256e108-fd9a-4c15-9548-7caa838d19b2/82f6466f-db8f-4c84-898c-e9dd4c4f56c0/Untitled.png)

< 메모 없이도 되겠네…? >

<aside>
💡 남은 횟수의 짝수/홀수 여부가 최단경로의 짝수/홀수 여부와 일치해야 한다.

</aside>

```cpp
// 탈출조건: 짝수, 홀수 불일치
if (distance % 2 != remainingMoves % 2)
    return false;
```

 예를 들어 최단 경로는 2이고 남은 횟수는 3일 때, 도달은 불가능하다. 마찬가지고 남은 횟수가 5, 7, 9, … 일 때에도 도달이 불가능한데, 짝수 번 이동해야 다시 현재 위치로 돌아오기 때문이다. ⇒ **통과**

# 비고

- 행렬의 그래프 탐색에 BFS/DFS, 다익스트라 이외에 다른 방법이 뭐가 있을까??
- BFS의 재귀를 백트래킹이라 할 수 있을까?
- 재귀가 아닌 큐를 써서 구현한다면?
- 메모 쓰려고 했는데 안 써도 된다는 것을 깨달음
- 오래 걸리네여…