### PR TITLE
[PROG] 42888 오픈채팅방 (cpp)

### DIFF
--- a/week06/42888_wonseok.cpp
+++ b/week06/42888_wonseok.cpp
@@ -1,0 +1,83 @@
+#include <string>
+#include <vector>
+#include <map>
+#include <iostream>
+
+using namespace std;
+
+vector<string> split(string s, string delim) {
+    vector<string> result;
+    string token;
+    
+    int pos=0;
+    while (pos = s.find(delim), pos != string::npos) {
+        token = s.substr(0, pos);
+        result.push_back(token);
+        
+        s.erase(0, pos+delim.length());
+    }
+    result.push_back(s);
+    
+    return result;
+}
+
+enum Command { ENTER, LEAVE, CHANGE, INVALID };
+
+struct Event {
+    string uid;
+    Command command;
+};
+
+class ChatRoom {
+public:
+    ChatRoom() {}
+    
+    void parse(string record) {
+        vector<string> splitted = split(record, " ");
+        
+        Command command = parseCommand(splitted[0]);
+        string uid = splitted[1];
+        
+        if (command == ENTER || command == CHANGE) {
+            string name = splitted[2];
+            users[uid] = name;
+        }
+        
+        events.push_back({uid, command});
+    }
+    
+    vector<string> getLogs() {
+        vector<string> logs;
+        
+        for (Event& event: events) {
+            string name = users[event.uid];
+            string log;
+            
+            if (event.command == CHANGE) continue;
+            if (event.command == ENTER) log = name + "님이 들어왔습니다.";
+            if (event.command == LEAVE) log = name + "님이 나갔습니다.";
+            logs.push_back(log);
+        }
+        
+        return logs;
+    }
+    
+private:
+    Command parseCommand(string command) {
+        if (command == "Enter") return ENTER;
+        if (command == "Leave") return LEAVE;
+        if (command == "Change") return CHANGE;
+        return INVALID;
+    }
+    
+    map<string, string> users;
+    vector<Event> events;
+};
+
+vector<string> solution(vector<string> record) {
+    ChatRoom room;
+    
+    for (auto event: record) room.parse(event);
+    
+    return room.getLogs();
+}


### PR DESCRIPTION
# 주제

- Implementation
- Hash Map

# 요약

1. 유저 id와 유저명을 저장할 해시맵을 준비한다.
2. record를 순회하여 유저명을 최신 상태로 업데이트한다.
    - ENTER, CHANGE일 때 유저명이 변경될 수 있다.
3. record를 다시 순회하여 메시지로 변환한다.
    - ENTER: ~님이 들어왔습니다.
    - LEAVE: ~님이 나갔습니다.
4. 변환한 메시지들을 반환한다.

# 접근

 처음에는 유저명 변경이 이전 결과에 전파된다는 점에서 Disjoint Set이 머릿속을 스쳤으나 병합할 집합이 없다는 것을 깨닫고 그만뒀다.

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/c256e108-fd9a-4c15-9548-7caa838d19b2/c358f219-6052-4add-8be0-45940a9cbda3/Untitled.png)

 유저 데이터(`uid`, `name`)와 메시지를 나누고, 메시지를 출력할 때에는 uid를 통해 유저명을 불러오도록 하면 쉽다. 데이터를 분리해서 데이터 독립성을 보장한다는 게 이런 게 아닐까?  

# 비고

- 데이터베이스의 데이터 독립성이란 무엇인지 알게 됐어요
- 카카오톡처럼 닉네임 변경이 곧바로 반영되도록 하려면…?
- C++ STL에 split() 좀 추가해주세요